### PR TITLE
Blindscan: Do not strip blindscan binaries and warning fix

### DIFF
--- a/recipes-bsp/drivers/os-blindscan-utils.bb
+++ b/recipes-bsp/drivers/os-blindscan-utils.bb
@@ -13,13 +13,14 @@ RPROVIDES_os-blindscan-dvbc-utils += "virtual/blindscan-dvbc"
 
 SRC_URI = "file://blindscan file://tda1002x"
 
-PV = "1.0"
-PR = "r0"
+PV = "1.1"
 
 S = "${WORKDIR}/"
 
 FILES_os-blindscan-dvbs-utils = "${bindir}/blindscan"
 FILES_os-blindscan-dvbc-utils = "${bindir}/tda1002x"
+
+INHIBIT_PACKAGE_STRIP = "1"
 
 do_install() {
 	install -d ${D}/${bindir}/


### PR DESCRIPTION
We should not attempt to strip the blindscan binaries.

Use INHIBIT_PACKAGE_STRIP to prevent strip and silence the following warning

WARNING: QA Issue: os-blindscan-utils: Files/directories were installed but not shipped in any package:
/usr/bin/.debug
/usr/bin/.debug/tda1002x
/usr/bin/.debug/blindscan
Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install.
os-blindscan-utils: 3 installed and not shipped files. [installed-vs-shipped]