### PR TITLE
Preinstall ralink usb wifi drivers

### DIFF
--- a/conf/machine/osmini.conf
+++ b/conf/machine/osmini.conf
@@ -11,6 +11,7 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "os-dvb-modules-osmini"
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "rtl8723bs"
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "kernel-module-cdfs"
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "kernel-module-hci-uart"
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "kernel-module-rt2800usb"
 
 MACHINE_EXTRA_RDEPENDS += "enigma2-plugin-systemplugins-vfdcontrol"
 MACHINE_EXTRA_RRECOMMENDS += "bluez-hcitools"

--- a/conf/machine/osminiplus.conf
+++ b/conf/machine/osminiplus.conf
@@ -11,6 +11,7 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "os-dvb-modules-osminiplus"
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "rtl8723bs"
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "kernel-module-cdfs"
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "kernel-module-hci-uart"
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "kernel-module-rt2800usb"
 
 MACHINE_EXTRA_RRECOMMENDS += "bluez-hcitools"
 MACHINE_EXTRA_RRECOMMENDS += "enigma2-plugin-drivers-dvb-usb-opticombo"


### PR DESCRIPTION
Required for automatically recognized Edision WLAN Stick Mega (Chipset: Ralink 5370)